### PR TITLE
Add an `export-theme` page to API docs

### DIFF
--- a/src/content/docs/api/export-theme.md
+++ b/src/content/docs/api/export-theme.md
@@ -1,0 +1,10 @@
+---
+title: Export theme
+description: Documentation about user’s capability to export a theme.
+---
+
+This is a placeholder to remember this documentation page needs to be written.
+
+## TBD
+
+TBD


### PR DESCRIPTION
This is a placeholder to avoid a 404 when reaching the `https://retraceur.github.io/api/export-theme` rel link used to check for the current user's capability to export a theme (REST API)

Fixes #11