### PR TITLE
Right Blocks Discovery to Blocks management relative link

### DIFF
--- a/src/content/docs/administration/discover-blocks.mdx
+++ b/src/content/docs/administration/discover-blocks.mdx
@@ -55,7 +55,7 @@ When you click the “Install” button, the installation begins, and after a fe
 
 ![Installation Ok](../../../assets/images/discover-block-us-005.png)
 
-If everything goes smoothly, you'll be prompted to either activate the block or view the [block management page](./manage-blocks).
+If everything goes smoothly, you'll be prompted to either activate the block or view the [block management page](../administration/manage-blocks).
 
 ## Support Contacts for a Block
 

--- a/src/content/docs/fr/administration/discover-blocks.mdx
+++ b/src/content/docs/fr/administration/discover-blocks.mdx
@@ -55,7 +55,7 @@ En cliquant sur le bouton «&nbsp;Installer&nbsp;», l'installation est lancée 
 
 ![Installation OK](../../../../assets/images/discover-block-fr-005.png)
 
-À partir du moment où tout se passe bien, vous serez invité soit à activer le bloc, soit à afficher la [page de gestion des blocs](./manage-blocks).
+À partir du moment où tout se passe bien, vous serez invité soit à activer le bloc, soit à afficher la [page de gestion des blocs](../../administration/manage-blocks).
 
 ## Contacts de Support d'un bloc
 


### PR DESCRIPTION
Looks like the right thing to do was `(../../administration/manage-blocks)` for French and `(../administration/manage-blocks)` for english.

Fixes #26